### PR TITLE
[Refactor] obscured noinput scripts for internal plugin use

### DIFF
--- a/plugins/shared/gittracker/gt.py
+++ b/plugins/shared/gittracker/gt.py
@@ -330,7 +330,7 @@ def CheckForGITUpdate(isGFBuilding):
 
 
         # Run deployments_noinput.py
-        deploy_script = os.path.abspath(os.path.join(os.getcwd(), "update", "deployments_noinput.py"))
+        deploy_script = os.path.abspath(os.path.join(os.getcwd(), "update", ".deployments_noinput.py"))
         #print(f"Debug: Checking deployments script at {deploy_script}")
         run_script(deploy_script, ["", "", ""])
 
@@ -371,12 +371,12 @@ def CheckForGITUpdate(isGFBuilding):
         Log.info("Godfinger change detected with isGFBuilding enabled. Triggering update...")
 
         # Run update_noinput.py
-        update_script = os.path.abspath(os.path.join(os.getcwd(), "update", "update_noinput.py"))
+        update_script = os.path.abspath(os.path.join(os.getcwd(), "update", ".update_noinput.py"))
         #print(f"Debug: Checking update script at {update_script}")
         run_script(update_script, ["Y", "Y", "Y"])
 
         # Run deployments_noinput.py with the same logic
-        deploy_script = os.path.abspath(os.path.join(os.getcwd(), "update", "deployments_noinput.py"))
+        deploy_script = os.path.abspath(os.path.join(os.getcwd(), "update", ".deployments_noinput.py"))
         #print(f"Debug: Checking deployments script at {deploy_script}")
         run_script(deploy_script, ["", "", ""])
 

--- a/prepare/bin/obscure_win.bat
+++ b/prepare/bin/obscure_win.bat
@@ -1,0 +1,9 @@
+@echo off
+
+::::::::::::::::::::::::::::::::::::::::::::::::::::::
+:: OBSCURES AUTOMATIC HIDDEN UPDATE FILES FROM USER ::
+::::::::::::::::::::::::::::::::::::::::::::::::::::::
+
+
+attrib +h "..\..\update\.update_noinput.py"
+attrib +h "..\..\update\.deployments_noinput.py"

--- a/prepare/win/prepare.bat
+++ b/prepare/win/prepare.bat
@@ -31,6 +31,15 @@ if %errorlevel% neq 0 (
     exit /b
 )
 
+:: Run the noinput obscuring script
+echo Obscuring update & deployments noinput files, as they are not intended to be used...
+call ./obscure_win.bat
+if %errorlevel% neq 0 (
+    echo Error running obscure_win.bat. Press Enter to exit.
+    pause
+    exit /b
+)
+
 :: Wait for user input before exiting
 goto end
 

--- a/update/.deployments_noinput.py
+++ b/update/.deployments_noinput.py
@@ -16,7 +16,8 @@ if os.name == 'nt':  # Windows
 
     if GIT_PATH is None:
         # If Git is not found, check a fallback directory
-        GIT_PATH = os.path.abspath(os.path.join("..", "venv", "GIT", "bin"))
+        PLUGIN_DIR = os.path.dirname(os.path.abspath(__file__))
+        GIT_PATH = os.path.abspath(os.path.join(PLUGIN_DIR, "..", "venv", "GIT", "bin"))
         GIT_EXECUTABLE = os.path.abspath(os.path.join(GIT_PATH, "git.exe"))
     else:
         GIT_EXECUTABLE = os.path.abspath(GIT_PATH)

--- a/update/update.py
+++ b/update/update.py
@@ -93,6 +93,8 @@ else:  # Non-Windows (Linux, macOS)
 # Function to check if Git is installed
 def check_git_installed():
     global GIT_EXECUTABLE
+    OS = platform.system()
+
     if shutil.which("git") or os.path.exists(GIT_EXECUTABLE):
         try:
             subprocess.run([GIT_EXECUTABLE, "--version"], check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
@@ -105,9 +107,9 @@ def check_git_installed():
         print("[ERROR] Git is not installed.")
         
         if platform.system() in ["Linux", "Darwin"]:
-            print("You will have to install Git manually on UNIX. Visit: https://git-scm.com/downloads")
+            print(f"You will have to install Git manually on {OS}. Visit: https://git-scm.com/downloads")
             input("Press Enter to exit...")
-            exit(0)
+            sys.exit(0)
         else:
             install_choice = input("Do you wish to install Git Portable in your virtual environment? (400mb~) (Y/N): ").strip().lower()
             if install_choice == 'y':
@@ -115,11 +117,11 @@ def check_git_installed():
                 GIT_EXECUTABLE = os.path.abspath(os.path.join("..", "venv", "GIT", "bin", "git.exe"))
                 os.environ["GIT_PYTHON_GIT_EXECUTABLE"] = GIT_EXECUTABLE
                 os.environ["PATH"] = os.path.dirname(GIT_PATH) + ";" + os.environ["PATH"]
-            return False
             if install_choice != 'y':
-                print("You will have to install Git manually. Visit: https://git-scm.com/downloads")
+                OS = platform.system()
+                print(f"You will have to install Git manually on {OS}. Visit: https://git-scm.com/downloads")
                 input("Press Enter to exit...")
-                exit(0)
+                sys.exit(0)
             return False
 
 # Function to download the Git archive (PortableGit)


### PR DESCRIPTION
> After sufficient testing, everything seems to be in order. Merging to dev.
> Additional misc changes, such as specifying OS when telling them to install GIT if it is not.
> Automatically obscures by applying +h hidden attribute to `.update_noinput.py` & `.deployments_noinput.py`
> The files are automatically hidden on Linux, due to `.` in front of the name.